### PR TITLE
[Fixes]-Update ANC proxy to latest staking contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anchor-token"
-version = "0.2.0"
+version = "0.3.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdad5465fce1e00e006a84153aca22c7212659bc2f4c1bbe27a2c27f96c6e8e3"
+checksum = "ff28d5ff6957c64ef8d40e4422bf45067c5e742e967e6a8dc8920e1558cce006"
 dependencies = [
  "cosmwasm-bignumber",
  "cosmwasm-std",
@@ -345,7 +345,6 @@ version = "0.0.0"
 dependencies = [
  "anchor-token",
  "astroport",
- "astroport-generator-proxy",
  "cosmwasm-bignumber",
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/proxy_to_anc/Cargo.toml
+++ b/contracts/proxy_to_anc/Cargo.toml
@@ -29,8 +29,7 @@ thiserror = { version = "1.0.24" }
 cw2 = "0.8.0"
 cw20 = "0.8.0"
 astroport = { version = "1.0.1" }
-astroport-generator-proxy = { path = "../../packages/astroport_generator_proxy", default-features = false, version = "1.0.0"}
-anchor-token = {version = "0.2.0"}
+anchor-token = {version = "0.3.0-alpha.1"}
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }

--- a/contracts/proxy_to_anc/README.md
+++ b/contracts/proxy_to_anc/README.md
@@ -2,7 +2,7 @@
 
 The generator proxy contract interacts with the Anchor LP staking contract (the Astroport dual rewards feature).
 
-Anchor LP Staking contract implementation: https://github.com/Anchor-Protocol/anchor-token-contracts/blob/main/contracts/staking/src/contract.rs
+Anchor LP Staking contract implementation: https://github.com/Anchor-Protocol/anchor-token-contracts/blob/0130f7474254ec44fb242101704ea89ee85ac83f/packages/anchor_token/src/staking.rs
 
 The staking via proxy guide is [here](https://miro.medium.com/max/1400/0*8hn2NSnZJZTa9YGV).
 

--- a/contracts/proxy_to_anc/src/contract.rs
+++ b/contracts/proxy_to_anc/src/contract.rs
@@ -13,6 +13,7 @@ use anchor_token::staking::{
 use astroport::generator_proxy::{
     CallbackMsg, ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
 };
+
 use cw2::set_contract_version;
 
 // version info for migration info
@@ -247,7 +248,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 cfg.reward_contract_addr,
                 &AncQueryMsg::StakerInfo {
                     staker: env.contract.address.to_string(),
-                    block_height: Some(env.block.height),
+                    block_time: Some(env.block.time.seconds()),
                 },
             )?;
             let deposit_amount = res.bond_amount;
@@ -269,7 +270,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 cfg.reward_contract_addr,
                 &AncQueryMsg::StakerInfo {
                     staker: env.contract.address.to_string(),
-                    block_height: Some(env.block.height),
+                    block_time: Some(env.block.time.seconds()),
                 },
             )?;
             let pending_reward = res.pending_reward;


### PR DESCRIPTION
- switch using `block_height` with `block_time` for anchor proxy for compatibility with latest anchor staking contract 